### PR TITLE
Added epsilon to scdataset.py to avoid NaN issues

### DIFF
--- a/astir/data/scdataset.py
+++ b/astir/data/scdataset.py
@@ -71,8 +71,9 @@ class SCDataset(Dataset):
                 "Classification failed. There "
                 + "should be at least one row of data to be classified."
             )
-        self._exprs_mean = self._exprs.mean(0)
-        self._exprs_std = self._exprs.std(0)
+        # adding epsilon to avoid NaN's down the line, which arise due to normalization when the stdev is 0
+        self._exprs_mean = self._exprs.mean(0) + 1e-6
+        self._exprs_std = self._exprs.std(0) + 1e-6
 
     def _process_df_input(self, df_input: pd.DataFrame) -> torch.Tensor:
         """Processes input as pd.DataFrame and convert it into torch.Tensor
@@ -335,7 +336,8 @@ class SCDataset(Dataset):
                 idx = idx.union(indices_to_use[i])
             mean_inits[feature] = df_exprs.loc[idx][feature].mean()
 
-        mean_init = pd.Series(mean_inits).to_numpy()
+        # adding an epsilon to avoid NaN's when logarithmizing during model initialization
+        mean_init = pd.Series(mean_inits).to_numpy() + 1e-6
 
         return mean_init
 


### PR DESCRIPTION
I ran into an issue while running astir on some of my data. The initial error looked like this:

```
_LinAlgError                              Traceback (most recent call last)
Cell In[178], line 1
----> 1 ast.fit_type(max_epochs=num_epochs, n_init=num_inits, n_init_epochs=num_epochs)

Cell In[175], line 157, in Astir.fit_type(self, max_epochs, learning_rate, batch_size, delta_loss, n_init, n_init_epochs)
    155 n_init_epochs = min(max_epochs, n_init_epochs)
    156 for i in range(n_init):
--> 157     type_models[i].fit(
    158         n_init_epochs,
    159         learning_rate,
    160         batch_size,
    161         delta_loss,
    162         msg=" " + str(i + 1) + "/" + str(n_init),
    163     )
    165 losses = torch.tensor([m.get_losses()[-1] for m in type_models])
    167 best_ind = int(torch.argmin(losses).item())

Cell In[174], line 279, in CellTypeModel.fit(self, max_epochs, learning_rate, batch_size, delta_loss, delta_loss_batch, msg)
    277 Y, X, design = batch
    278 optimizer.zero_grad()
--> 279 L = self._forward(Y, X, design)
    280 L.backward()
    281 optimizer.step()

Cell In[174], line 212, in CellTypeModel._forward(self, Y, X, design)
    208 v1 = v1.view(1, C + 1, G, 1).repeat(N, 1, 1, 1)  # extra 1 is the "rank"
    209 v2 = v2.view(1, C + 1, G).repeat(N, 1, 1) + 1e-6
--> 212 dist = LowRankMultivariateNormal(
    213     loc=torch.exp(mean).permute(0, 2, 1), cov_factor=v1, cov_diag=v2
    214 )
    216 log_p_y_on_c = dist.log_prob(Y_spread)
    218 gamma, log_gamma = self._recog.forward(X)

File ~/meyerben/.conda/envs/pipeline_env/lib/python3.10/site-packages/torch/distributions/lowrank_multivariate_normal.py:123, in LowRankMultivariateNormal.__init__(self, loc, cov_factor, cov_diag, validate_args)
    121 self._unbroadcasted_cov_factor = cov_factor
    122 self._unbroadcasted_cov_diag = cov_diag
--> 123 self._capacitance_tril = _batch_capacitance_tril(cov_factor, cov_diag)
    124 super().__init__(batch_shape, event_shape, validate_args=validate_args)

File ~/meyerben/.conda/envs/pipeline_env/lib/python3.10/site-packages/torch/distributions/lowrank_multivariate_normal.py:21, in _batch_capacitance_tril(W, D)
     19 K = torch.matmul(Wt_Dinv, W).contiguous()
     20 K.view(-1, m * m)[:, :: m + 1] += 1  # add identity matrix to K
---> 21 return torch.linalg.cholesky(K)

_LinAlgError: linalg.cholesky: (Batch element 0): The factorization could not be completed because the input is not positive-definite (the leading minor of order 1 is not positive-definite).
```

Note that the bug actually looks different when running astir on a GPU (see [this issue](https://github.com/pytorch/pytorch/issues/64818)):

```
ValueError: Expected parameter loc (Tensor of shape (128, 11, 10)) of distribution LowRankMultivariateNormal(loc: torch.Size([128, 11, 10]), cov_factor: torch.Size([128, 11, 10, 1]), cov_diag: torch.Size([128, 11, 10])) to satisfy the constraint IndependentConstraint(Real(), 1), but found invalid values:
tensor([[[nan, nan, nan,  ..., nan, nan, nan],
         [nan, nan, nan,  ..., nan, nan, nan],
         [nan, nan, nan,  ..., nan, nan, nan]
...
```

The issue is with how some of the variables are initialized. They look like this:
```
{'mu': tensor([[-1.2535],
        [-6.1567],
        [   -inf],
        [-9.2548],
        [-9.9480],
        [-0.3783],
        [-2.4062],
        [-1.7017],
        [-6.7316],
        [   -inf]], dtype=torch.float64, requires_grad=True), 'log_sigma': tensor([-1.3104, -5.2150,    -inf, -6.8624, -4.8441, -0.8369, -2.3961, -1.8803,
        -4.2628,    -inf], dtype=torch.float64, requires_grad=True), 'log_delta': ...}
```

Notice that for mu and log_sigma, the initializations are `-inf` for some of the markers. I did a little digging for mu, and found the cause. The issue is in `SCDataset ` in the method `get_mu_init()`. What happens is that `mean_init` looks something like this: `[2.85493013e-01 2.11918732e-03 0.00000000e+00 9.56473410e-05 4.78239234e-05 6.85015690e-01 9.01530617e-02 1.82373140e-01 1.19259807e-03 0.00000000e+00]`. Notice that two of the values are 0. This leads to `-inf` values when taking the log, and consequently produces `NaN` matrices downstream.

My suggestion would hence be to replace the line `mean_init = pd.Series(mean_inits).to_numpy()` with something like `mean_init = pd.Series(mean_inits).to_numpy() + 1e-6`. 

For sigma, the same concept applies. I hence added 1e-6 to the mean and standard deviation in the SCDataset. Note that you cannot just add the epsilon in the `get_sigma()` method, since `__getitem__` also divides by the standard deviation, which can lead to NaN's in the dataloader.

If you want to reproduce this behavior, you can download [this file](https://oc.embl.de/index.php/s/WIZdQZXYIYzQuim) and try running astir on it.

Best,
Matthias

Sidenote:
Simply adding 1e-6 to the input data does not solve the problem. While this does fix the issue for mu, log_sigma still contains `NaN` values with this approach, since the standard deviation will be 0.